### PR TITLE
Update moduleInit.R to check env for modulecmd

### DIFF
--- a/R/moduleInit.R
+++ b/R/moduleInit.R
@@ -12,7 +12,7 @@ moduleInit <- function( version = '3.2.10',
 
   # Check if modulecmd exists in the bin directory of modulesHome
   module_cmd <- file.path(modulesHome, "bin", "modulecmd")
-  if(!file.exists(module_cmd)){
+  if(!file.exists(module_cmd) && Sys.which("modulecmd") == ""){
     stop(module_cmd, " missing!\n",
          "  Module environment init failed!" )
   }


### PR DESCRIPTION
Fail only if `modulecmd` is not in the installation tree and not on the `PATH`.

Merging into my own main branch for testing.